### PR TITLE
Add FLASK_APP environment variable to fix Flask application detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM python:3.10-slim-bullseye
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     PYTHONUNBUFFERED=1 \
+    FLASK_APP=superset \
     SUPERSET_HOME=/app/superset \
     SUPERSET_CONFIG_PATH=/app/superset/superset_config.py
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       dockerfile: Dockerfile
     container_name: superset-app
     environment:
+      - FLASK_APP=superset
       - SUPERSET_SECRET_KEY=${SUPERSET_SECRET_KEY:-changeme-secretkey-for-production}
       - DATABASE_DIALECT=postgresql
       - DATABASE_USER=${POSTGRES_USER:-superset}


### PR DESCRIPTION
- Set FLASK_APP=superset in Dockerfile
- Add FLASK_APP to docker-compose.yml environment
- This fixes 'Could not locate a Flask application' error