### PR TITLE
Add flask-cors dependency to fix CORS module error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
     apache-superset \
     psycopg2-binary \
     redis \
-    celery
+    celery \
+    flask-cors
 
 # Create superset directories
 RUN mkdir -p ${SUPERSET_HOME} /app/superset_home


### PR DESCRIPTION
- Add flask-cors to pip install list
- Required by ENABLE_CORS configuration in superset_config.py