### PR TITLE
Pin marshmallow version and add clean rebuild script

### DIFF
--- a/CLEAN_REBUILD.sh
+++ b/CLEAN_REBUILD.sh
@@ -1,0 +1,26 @@
+# Clean Rebuild Script
+
+Run these commands to force a complete rebuild without cache:
+
+```bash
+# Stop and remove everything
+docker compose down -v
+
+# Remove the old image
+docker rmi superset-app:latest 2>/dev/null || true
+docker rmi ode-viz-superset 2>/dev/null || true
+
+# Clean build cache
+docker builder prune -f
+
+# Rebuild from scratch (no cache)
+docker compose build --no-cache
+
+# Start
+docker compose up -d
+
+# Watch logs
+docker compose logs -f superset
+```
+
+This ensures Docker doesn't use any cached layers from previous builds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ WORKDIR /app
 # Install Apache Superset with all optional dependencies
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir \
+    'marshmallow>=3.18.0,<4.0.0' \
     'apache-superset[postgres,redis,celery,cors]' \
     psycopg2-binary
 


### PR DESCRIPTION
- Pin marshmallow to >=3.18.0,<4.0.0 to fix minLength error
- Add CLEAN_REBUILD.sh with instructions for complete rebuild
- Ensures compatible marshmallow version is installed first