### PR TITLE
Fix GitHub Actions Docker build permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # Note: Configuration file is mounted via volume in docker-compose.yml
 # No need to COPY during build
 
-# Create superset user
-RUN useradd -m -d /app superset && \
+# Create superset user (without -m flag to avoid home directory creation conflicts)
+RUN useradd --no-create-home --home-dir /app superset && \
     chown -R superset:superset /app
 
 # Switch to superset user


### PR DESCRIPTION
Changed useradd from:
  useradd -m -d /app superset

To:
  useradd --no-create-home --home-dir /app superset

Issue: The -m flag tries to create a home directory, which on the self-hosted runner (running as user 'docker') was causing: 'mkdir /home/docker: permission denied'

The --no-create-home flag explicitly prevents home directory creation, avoiding the permission issue. We don't need a home directory anyway since the working directory is /app.